### PR TITLE
Writes successful message to stdout instead of stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Flags:
   -p, --platform strings   specify platforms in the format os/arch to look for in container images. Default behavior is to look for any platform.
 ```
 
-If `IMAGE:TAG` exists, this simply outputs `found`. This is intended to be used in CI environments to automate checking for existing container images before pushing. By default, `container-tag-exists` looks for any existing container image with the given tag.
+If `IMAGE:TAG` exists, this simply writes `found` to standard output. This is intended to be used in CI environments to automate checking for existing container images before pushing. By default, `container-tag-exists` looks for any existing container image with the given tag.
 
 ```sh
 container-tag-exists ghcr.io/example 0.0.0

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -55,7 +56,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if hasTag {
-		cmd.Println("found")
+		fmt.Println("found")
 	}
 	return nil
 }


### PR DESCRIPTION
This PR changes the output stream for the successful message from stderr to stdout.
stderr is suitable for error messages and usage messages.  For successful messages, stdout would be suitable.

Signed-off-by: morimoto-cybozu <kenji_morimoto@cybozu.co.jp>
